### PR TITLE
Reverse lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iptmon
-PKG_VERSION:=0.1.1
+PKG_VERSION:=0.1.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Jordan Sokolic <oofnik@gmail.com>
 
 PKG_SOURCE_PROTO=git
 PKG_SOURCE_URL:=https://github.com/oofnikj/iptmon
-PKG_SOURCE_DATE:=2020-11-07
-PKG_SOURCE_VERSION:=v0.1.1
+PKG_SOURCE_DATE:=2020-11-15
+PKG_SOURCE_VERSION:=v${PKG_VERSION}
 
 
 include $(INCLUDE_DIR)/package.mk

--- a/files/usr/sbin/iptmon
+++ b/files/usr/sbin/iptmon
@@ -89,6 +89,12 @@ test_family() {
 	fi
 }
 
+reverse_lookup() {
+	local ip
+	ip=$1
+	nslookup ${ip} | grep 'name = ' | sed -E 's/^.*name = ([a-zA-Z0-9-]+).*$/\1/'
+}
+
 dnsmasq_add() {
 	mac=$1
 	ip=$2
@@ -132,7 +138,7 @@ dnsmasq_add() {
 dnsmasq_arp_add() {
 	mac=$1
 	ip=$2
-	host=$( grep $mac $LEASE_FILE | awk '{print $4}' )
+	host=$( reverse_lookup ${ip} )
 	test "${host}x" == 'x' || dnsmasq_add $mac $ip $host
 }
 
@@ -164,7 +170,7 @@ dnsmasq_del() {
 dnsmasq_arp_del() {
 	mac=$1
 	ip=$2
-	host=$( grep $mac $LEASE_FILE | awk '{print $4}' )
+	host=$( reverse_lookup ${ip} )
 	dnsmasq_del $mac $ip $host
 }
 


### PR DESCRIPTION
fixes issue where static host disappears from ARP table, gets deleted from `iptmon`, then doesn't get re-added.